### PR TITLE
Add password reset functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ RESPONSE:
 }
 ```
 
+#### Reset the password for a user
+```javascript
+POST /api/users/register
+{
+  email: String,
+}
+
+RESPONSE:
+{}
+```
+
 #### Activate a user
 **Note:** Currently deprecated (we're not requiring email verification)
 ```javascript

--- a/app/emails/passwordReset/html.jade
+++ b/app/emails/passwordReset/html.jade
@@ -1,0 +1,10 @@
+extends ../template
+
+block content
+  h1 Hello,
+  p
+    | Sorry you had to reset your password. Go to <a href="http://khe.io/password/reset">khe.io/password/reset</a>
+    | and enter this token: "#{token}"
+  p
+    | Regards, <br>
+    | The Kent Hack Enough Team

--- a/app/emails/passwordReset/text.txt
+++ b/app/emails/passwordReset/text.txt
@@ -1,0 +1,7 @@
+Hello.
+
+Sorry you had to reset your password. The token can currently only be view from
+a email viewer with support for html.
+
+Regards,
+The Kent Hack Enough Team

--- a/app/modules/users/model.js
+++ b/app/modules/users/model.js
@@ -29,12 +29,16 @@ var bcrypt = require('bcrypt');
 var auth = require('basic-auth');
 var schema = require('validate');
 var Application = require('../applications/model');
+var chance = require('chance').Chance();
+
 
 var User = mongoose.model('User', {
   email: {type: String, unique: true},
   role: {type: String, enum: ['attendee', 'staff', 'admin']},
   password: String,
   salt: String,
+  resetToken: String,                 // used authenticate a password reset
+  resetRequested : Date,              // time reset was requested
   subscribe: Boolean,                 // subscribe to the mailing list?
   activated: Boolean,                 // account activated?
   application: Application.Schema,    // user's application
@@ -49,6 +53,14 @@ var Helpers = {
   */
   salt: function () {
     return bcrypt.genSaltSync(10);
+  },
+
+  /**
+  * Generate a random string for use as a token
+  * @return A random string with 10 bytes
+  */
+  token: function() {
+    return chance.string({length: 10}); // todo use a stronger random function
   },
 
   /**

--- a/config_example.js
+++ b/config_example.js
@@ -3,8 +3,11 @@ module.exports = {
   // API Port
   port: 3000,
 
- // Log file (check for errors here)
+  // Log file (check for errors here)
   log: 'app.log',
+
+  // Period after a password update request in which the token is valid in ms
+  tokenValidity: 86400000, // 24 hours
 
   // Database to save users and other data to
   mongo: {

--- a/test/test.js
+++ b/test/test.js
@@ -86,6 +86,38 @@ describe('API', function () {
         });
     });
 
+    // not the best way of testing this but without email we can't do better
+    it('should ask for a password reset', function (done) {
+      request(app)
+        .post('/api/users/password/reset/request')
+        .send({
+          email: 'user@test.com'
+        })
+        .expect(200)
+        .end(function (err, res) {
+          if (err) throw err;
+          JSON.stringify(res.body).should.be.exactly("{}");
+          done();
+        });
+    });
+
+    // once again not the best test but without knowing the token we must make do
+    it('should fail to reset password with wrong token', function (done) {
+      request(app)
+        .post('/api/users/password/reset')
+        .send({
+          email: 'user@test.com',
+          token: 'adadsdsf',
+          password: 'hah hah this works'
+        })
+        .expect(200)
+        .end(function (err, res) {
+          if (err) throw err;
+          res.body.errors[0].should.equal('The token or email is incorrect');
+          done();
+        });
+    });
+
     it('should update the user\'s role', function (done) {
       request(app)
         .post('/api/users/role/' + id)


### PR DESCRIPTION
Adds functionality to be used to reset the users password. Also currently the only way to change the users password. Probably will want to change that.

The detractors have been mentioned in the accompanying commit. There are a few but the big one is that token generation, critical for the security of resetting a password, currently is using a cryptographically weak random number generator. This means in theory someone could guess with some much greater than random probability the token that will be used at any particular time. We probably should use something more secure, but the options I found all seemed overly complicated and had unclear restrictions on the rate of their use.

Other than that there isn't much to say. The password reset email isn't the best, but that is mostly due to a lack of a proper implementation in the web interface which should involve the token being inserted into the URL and the email can be easily updated when we arrive at a more concrete interface.

p.s Don't ask me how it decided I was spaceFountain. Sorry about that I thought I'd reset the user info. As a side note GitHub and git in general does not make it easy at all to change users.