### PR TITLE
Filter broken resumes when exporting

### DIFF
--- a/app/exports/controller.js
+++ b/app/exports/controller.js
@@ -61,7 +61,7 @@ module.exports = {
         if (err) return res.internalError();
 
         let files = applications.filter((application) => {
-          return application.resume;
+          return application.resume && application.resume.length > 0;
         }).map((application) => {
 
           // normalize file names


### PR DESCRIPTION
Right now we have applications with the resume file name equal to a empty string. This breaks the export process.

In theory this should filter these cases out, but I'm at work on lunch so I can't try.